### PR TITLE
Convert to use python3

### DIFF
--- a/README
+++ b/README
@@ -11,14 +11,14 @@ This plugin is known to work with the following flavours of Vim:
   * Linux (tested on Ubuntu 12.04/12.10):
       * vim/gvim (from vim-gnome package version 7.3)
 
-  * Mac OS X (tested on Mountain Lion)
-      * Vim command-line (7.3 from Xcode)
+  * macOS (tested on Monterey)
+      * Vim command-line (8.2 from homebrew)
       * MacVim 7.3
 
 To install the plugin, ensure you have
   * a working version of lldb on your path, or the environment variable LLDB
     pointing to the lldb binary you would like to use.
-  * a python-enabled vim (check with ":python print 2")
+  * a python3-enabled vim (check with "vim --version | grep python3")
 
 
 Installation

--- a/plugin/lldb.vim
+++ b/plugin/lldb.vim
@@ -13,11 +13,11 @@ function! s:FindPythonScriptDir()
 endfunction()
 
 function! s:InitLldbPlugin()
-  if has('python') == 0
-    call confirm('ERROR: This Vim installation does not have python support. lldb.vim will not work.')
+  if !has('python3')
+    call confirm('ERROR: This Vim installation does not have python3 support. lldb.vim will not work.')
     return
   endif
-  
+
   " Key-Bindings
   " FIXME: choose sensible keybindings for:
   " - process: start, interrupt, continue, continue-to-cursor
@@ -29,10 +29,10 @@ function! s:InitLldbPlugin()
   endif
 
   "
-  " Setup the python interpreter path
+  " Setup the python3 interpreter path
   "
   let vim_lldb_pydir = s:FindPythonScriptDir()
-  execute 'python import sys; sys.path.append("' . vim_lldb_pydir . '")'
+  execute 'python3 import sys; sys.path.append("' . vim_lldb_pydir . '")'
 
   "
   " Register :L<Command>
@@ -41,86 +41,86 @@ function! s:InitLldbPlugin()
   "
 
   " Window show/hide commands
-  command -complete=custom,s:CompleteWindow -nargs=1 Lhide               python ctrl.doHide('<args>')
-  command -complete=custom,s:CompleteWindow -nargs=0 Lshow               python ctrl.doShow('<args>')
- 
+  command -complete=custom,s:CompleteWindow -nargs=1 Lhide               python3 ctrl.doHide('<args>')
+  command -nargs=0 Lshow                                                 python3 ctrl.doShow('<args>')
+
   " Launching convenience commands (no autocompletion)
-  command -nargs=* Lstart                                                python ctrl.doLaunch(True,  '<args>')
-  command -nargs=* Lrun                                                  python ctrl.doLaunch(False, '<args>')
-  command -nargs=1 Lattach                                               python ctrl.doAttach('<args>')
-  command -nargs=0 Ldetach                                               python ctrl.doDetach()
+  command -nargs=* Lstart                                                python3 ctrl.doLaunch(True,  '<args>')
+  command -nargs=* Lrun                                                  python3 ctrl.doLaunch(False, '<args>')
+  command -nargs=1 Lattach                                               python3 ctrl.doAttach('<args>')
+  command -nargs=0 Ldetach                                               python3 ctrl.doDetach()
 
   " Regexp-commands: because vim's command mode does not support '_' or '-'
   " characters in command names, we omit them when creating the :L<cmd>
   " equivalents.
-  command -complete=custom,s:CompleteCommand -nargs=* Lregexpattach      python ctrl.doCommand('_regexp-attach', '<args>')
-  command -complete=custom,s:CompleteCommand -nargs=* Lregexpbreak       python ctrl.doCommand('_regexp-break', '<args>')
-  command -complete=custom,s:CompleteCommand -nargs=* Lregexpbt          python ctrl.doCommand('_regexp-bt', '<args>')
-  command -complete=custom,s:CompleteCommand -nargs=* Lregexpdown        python ctrl.doCommand('_regexp-down', '<args>')
-  command -complete=custom,s:CompleteCommand -nargs=* Lregexptbreak      python ctrl.doCommand('_regexp-tbreak', '<args>')
-  command -complete=custom,s:CompleteCommand -nargs=* Lregexpdisplay     python ctrl.doCommand('_regexp-display', '<args>')
-  command -complete=custom,s:CompleteCommand -nargs=* Lregexpundisplay   python ctrl.doCommand('_regexp-undisplay', '<args>')
-  command -complete=custom,s:CompleteCommand -nargs=* Lregexpup          python ctrl.doCommand('_regexp-up', '<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Lregexpattach      python3 ctrl.doCommand('_regexp-attach', '<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Lregexpbreak       python3 ctrl.doCommand('_regexp-break', '<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Lregexpbt          python3 ctrl.doCommand('_regexp-bt', '<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Lregexpdown        python3 ctrl.doCommand('_regexp-down', '<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Lregexptbreak      python3 ctrl.doCommand('_regexp-tbreak', '<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Lregexpdisplay     python3 ctrl.doCommand('_regexp-display', '<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Lregexpundisplay   python3 ctrl.doCommand('_regexp-undisplay', '<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Lregexpup          python3 ctrl.doCommand('_regexp-up', '<args>')
 
-  command -complete=custom,s:CompleteCommand -nargs=* Lapropos           python ctrl.doCommand('apropos', '<args>')
-  command -complete=custom,s:CompleteCommand -nargs=* Lbacktrace         python ctrl.doCommand('bt', '<args>')
-  command -complete=custom,s:CompleteCommand -nargs=* Lbreakpoint        python ctrl.doBreakpoint('<args>')
-  command -complete=custom,s:CompleteCommand -nargs=* Lcommand           python ctrl.doCommand('command', '<args>')
-  command -complete=custom,s:CompleteCommand -nargs=* Ldisassemble       python ctrl.doCommand('disassemble', '<args>')
-  command -complete=custom,s:CompleteCommand -nargs=* Lexpression        python ctrl.doCommand('expression', '<args>')
-  command -complete=custom,s:CompleteCommand -nargs=* Lhelp              python ctrl.doCommand('help', '<args>')
-  command -complete=custom,s:CompleteCommand -nargs=* Llog               python ctrl.doCommand('log', '<args>')
-  command -complete=custom,s:CompleteCommand -nargs=* Lplatform          python ctrl.doCommand('platform','<args>')
-  command -complete=custom,s:CompleteCommand -nargs=* Lplugin            python ctrl.doCommand('plugin', '<args>')
-  command -complete=custom,s:CompleteCommand -nargs=* Lprocess           python ctrl.doProcess('<args>')
-  command -complete=custom,s:CompleteCommand -nargs=* Lregister          python ctrl.doCommand('register', '<args>')
-  command -complete=custom,s:CompleteCommand -nargs=* Lscript            python ctrl.doCommand('script', '<args>')
-  command -complete=custom,s:CompleteCommand -nargs=* Lsettings          python ctrl.doCommand('settings','<args>')
-  command -complete=custom,s:CompleteCommand -nargs=* Lsource            python ctrl.doCommand('source', '<args>')
-  command -complete=custom,s:CompleteCommand -nargs=* Ltype              python ctrl.doCommand('type', '<args>')
-  command -complete=custom,s:CompleteCommand -nargs=* Lversion           python ctrl.doCommand('version', '<args>')
-  command -complete=custom,s:CompleteCommand -nargs=* Lwatchpoint        python ctrl.doCommand('watchpoint', '<args>')
- 
+  command -complete=custom,s:CompleteCommand -nargs=* Lapropos           python3 ctrl.doCommand('apropos', '<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Lbacktrace         python3 ctrl.doCommand('bt', '<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Lbreakpoint        python3 ctrl.doBreakpoint('<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Lcommand           python3 ctrl.doCommand('command', '<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Ldisassemble       python3 ctrl.doCommand('disassemble', '<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Lexpression        python3 ctrl.doCommand('expression', '<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Lhelp              python3 ctrl.doCommand('help', '<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Llog               python3 ctrl.doCommand('log', '<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Lplatform          python3 ctrl.doCommand('platform','<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Lplugin            python3 ctrl.doCommand('plugin', '<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Lprocess           python3 ctrl.doProcess('<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Lregister          python3 ctrl.doCommand('register', '<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Lscript            python3 ctrl.doCommand('script', '<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Lsettings          python3 ctrl.doCommand('settings','<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Lsource            python3 ctrl.doCommand('source', '<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Ltype              python3 ctrl.doCommand('type', '<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Lversion           python3 ctrl.doCommand('version', '<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Lwatchpoint        python3 ctrl.doCommand('watchpoint', '<args>')
+
   " Convenience (shortcut) LLDB commands
-  command -complete=custom,s:CompleteCommand -nargs=* Lprint             python ctrl.doCommand('print', vim.eval("s:CursorWord('<args>')"))
-  command -complete=custom,s:CompleteCommand -nargs=* Lpo                python ctrl.doCommand('po', vim.eval("s:CursorWord('<args>')"))
-  command -complete=custom,s:CompleteCommand -nargs=* LpO                python ctrl.doCommand('po', vim.eval("s:CursorWORD('<args>')"))
-  command -complete=custom,s:CompleteCommand -nargs=* Lbt                python ctrl.doCommand('bt', '<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Lprint             python3 ctrl.doCommand('print', vim.eval("s:CursorWord('<args>')"))
+  command -complete=custom,s:CompleteCommand -nargs=* Lpo                python3 ctrl.doCommand('po', vim.eval("s:CursorWord('<args>')"))
+  command -complete=custom,s:CompleteCommand -nargs=* LpO                python3 ctrl.doCommand('po', vim.eval("s:CursorWORD('<args>')"))
+  command -complete=custom,s:CompleteCommand -nargs=* Lbt                python3 ctrl.doCommand('bt', '<args>')
 
   " Frame/Thread-Selection (commands that also do an Uupdate but do not
   " generate events in LLDB)
-  command -complete=custom,s:CompleteCommand -nargs=* Lframe             python ctrl.doSelect('frame', '<args>')
-  command -complete=custom,s:CompleteCommand -nargs=? Lup                python ctrl.doCommand('up', '<args>',     print_on_success=False, goto_file=True)
-  command -complete=custom,s:CompleteCommand -nargs=? Ldown              python ctrl.doCommand('down', '<args>', print_on_success=False, goto_file=True)
-  command -complete=custom,s:CompleteCommand -nargs=* Lthread            python ctrl.doSelect('thread', '<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Lframe             python3 ctrl.doSelect('frame', '<args>')
+  command -complete=custom,s:CompleteCommand -nargs=? Lup                python3 ctrl.doCommand('up', '<args>',     print_on_success=False, goto_file=True)
+  command -complete=custom,s:CompleteCommand -nargs=? Ldown              python3 ctrl.doCommand('down', '<args>', print_on_success=False, goto_file=True)
+  command -complete=custom,s:CompleteCommand -nargs=* Lthread            python3 ctrl.doSelect('thread', '<args>')
 
-  command -complete=custom,s:CompleteCommand -nargs=* Ltarget            python ctrl.doTarget('<args>')
+  command -complete=custom,s:CompleteCommand -nargs=* Ltarget            python3 ctrl.doTarget('<args>')
 
   " Continue
-  command -complete=custom,s:CompleteCommand -nargs=* Lcontinue          python ctrl.doContinue()
+  command -complete=custom,s:CompleteCommand -nargs=* Lcontinue          python3 ctrl.doContinue()
 
   " Thread-Stepping (no autocompletion)
-  command -nargs=0 Lstepinst                                             python ctrl.doStep(StepType.INSTRUCTION)
-  command -nargs=0 Lstepinstover                                         python ctrl.doStep(StepType.INSTRUCTION_OVER)
-  command -nargs=0 Lstepin                                               python ctrl.doStep(StepType.INTO)
-  command -nargs=0 Lstep                                                 python ctrl.doStep(StepType.INTO)
-  command -nargs=0 Lnext                                                 python ctrl.doStep(StepType.OVER)
-  command -nargs=0 Lfinish                                               python ctrl.doStep(StepType.OUT)
+  command -nargs=0 Lstepinst                                             python3 ctrl.doStep(StepType.INSTRUCTION)
+  command -nargs=0 Lstepinstover                                         python3 ctrl.doStep(StepType.INSTRUCTION_OVER)
+  command -nargs=0 Lstepin                                               python3 ctrl.doStep(StepType.INTO)
+  command -nargs=0 Lstep                                                 python3 ctrl.doStep(StepType.INTO)
+  command -nargs=0 Lnext                                                 python3 ctrl.doStep(StepType.OVER)
+  command -nargs=0 Lfinish                                               python3 ctrl.doStep(StepType.OUT)
 
   " hack: service the LLDB event-queue when the cursor moves
   " FIXME: some threaded solution would be better...but it
   "        would have to be designed carefully because Vim's APIs are non threadsafe;
   "        use of the vim module **MUST** be restricted to the main thread.
-  command -nargs=0 Lrefresh python ctrl.doRefresh()
+  command -nargs=0 Lrefresh python3 ctrl.doRefresh()
   autocmd CursorMoved * :Lrefresh
   autocmd CursorHold  * :Lrefresh
-  autocmd VimLeavePre * python ctrl.doExit()
+  autocmd VimLeavePre * python3 ctrl.doExit()
 
-  execute 'pyfile ' . vim_lldb_pydir . '/plugin.py'
+  execute 'py3file ' . vim_lldb_pydir . '/plugin.py'
 endfunction()
 
 function! s:CompleteCommand(A, L, P)
-  python << EOF
+  python3 << EOF
 a = vim.eval("a:A")
 l = vim.eval("a:L")
 p = vim.eval("a:P")
@@ -129,7 +129,7 @@ EOF
 endfunction()
 
 function! s:CompleteWindow(A, L, P)
-  python << EOF
+  python3 << EOF
 a = vim.eval("a:A")
 l = vim.eval("a:L")
 p = vim.eval("a:P")

--- a/python-vim-lldb/import_lldb.py
+++ b/python-vim-lldb/import_lldb.py
@@ -36,7 +36,7 @@ def import_lldb():
                 "%s -P" %
                 lldb_executable,
                 shell=True,
-                stderr=fnull).strip()
+                stderr=fnull).strip().decode()
         if not os.path.exists(lldb_minus_p_path):
             # lldb -P returned invalid path, probably too old
             pass

--- a/python-vim-lldb/vim_panes.py
+++ b/python-vim-lldb/vim_panes.py
@@ -368,9 +368,8 @@ class VimPane(object):
         """ replace buffer with msg"""
         self.prepare()
 
-        msg = str(msg.encode("utf-8", "replace")).split('\n')
         try:
-            self.buffer.append(msg)
+            self.buffer.append(msg.splitlines())
             vim.command("execute \"normal ggdd\"")
         except vim.error:
             # cannot update window; happens when vim is exiting.


### PR DESCRIPTION
This converts this plugin to require python3 and not support python2 since it has long been end of life and is finally gone from macOS as well.

Fixes https://github.com/lldb-tools/vim-lldb/issues/3