### PR TITLE
Improve error handling

### DIFF
--- a/plugin/lldb.vim
+++ b/plugin/lldb.vim
@@ -18,6 +18,23 @@ function! s:InitLldbPlugin()
     return
   endif
 
+  "
+  " Setup the python3 interpreter path
+  "
+  let vim_lldb_pydir = s:FindPythonScriptDir()
+  try
+    execute 'python3 import sys; sys.path.append("' . vim_lldb_pydir . '")'
+    execute 'py3file ' . vim_lldb_pydir . '/plugin.py'
+  catch
+    echom 'Error loading lldb module; vim-lldb will be disabled. Check LLDB installation or set LLDB environment variable.'
+    return
+  endtry
+
+  if exists("s:lldb_disabled")
+    echom 'Error loading lldb module; vim-lldb will be disabled. Check LLDB installation or set LLDB environment variable.'
+    return
+  endif
+
   " Key-Bindings
   " FIXME: choose sensible keybindings for:
   " - process: start, interrupt, continue, continue-to-cursor
@@ -27,12 +44,6 @@ function! s:InitLldbPlugin()
     " Apple-B toggles breakpoint on cursor
     map <D-B>     :Lbreakpoint<CR>
   endif
-
-  "
-  " Setup the python3 interpreter path
-  "
-  let vim_lldb_pydir = s:FindPythonScriptDir()
-  execute 'python3 import sys; sys.path.append("' . vim_lldb_pydir . '")'
 
   "
   " Register :L<Command>
@@ -115,8 +126,6 @@ function! s:InitLldbPlugin()
   autocmd CursorMoved * :Lrefresh
   autocmd CursorHold  * :Lrefresh
   autocmd VimLeavePre * python3 ctrl.doExit()
-
-  execute 'py3file ' . vim_lldb_pydir . '/plugin.py'
 endfunction()
 
 function! s:CompleteCommand(A, L, P)
@@ -138,14 +147,14 @@ EOF
 endfunction()
 
 " Returns cword if search term is empty
-function! s:CursorWord(term) 
-  return empty(a:term) ? expand('<cword>') : a:term 
+function! s:CursorWord(term)
+  return empty(a:term) ? expand('<cword>') : a:term
 endfunction()
 
 " Returns cleaned cWORD if search term is empty
-function! s:CursorWORD(term) 
+function! s:CursorWORD(term)
   " Will strip all non-alphabetic characters from both sides
-  return empty(a:term) ?  substitute(expand('<cWORD>'), '^\A*\(.\{-}\)\A*$', '\1', '') : a:term 
+  return empty(a:term) ?  substitute(expand('<cWORD>'), '^\A*\(.\{-}\)\A*$', '\1', '') : a:term
 endfunction()
 
 call s:InitLldbPlugin()

--- a/python-vim-lldb/import_lldb.py
+++ b/python-vim-lldb/import_lldb.py
@@ -66,6 +66,4 @@ def import_lldb():
 
 if not import_lldb():
     import vim
-    vim.command(
-        'redraw | echo "%s"' %
-        " Error loading lldb module; vim-lldb will be disabled. Check LLDB installation or set LLDB environment variable.")
+    vim.command("let s:lldb_disabled=1")


### PR DESCRIPTION
This moves the lldb importing above all the command mapping so if
importing fails we don't register any commands that wouldn't actually
work. In the case of things that were done with autocommands not doing
this resulted in infinite errors as you used vim.

Partially taken from https://github.com/lldb-tools/vim-lldb/pull/1